### PR TITLE
pegdown Extensions.TABLES

### DIFF
--- a/src/main/java/annotatedspring/episodes/Episode.java
+++ b/src/main/java/annotatedspring/episodes/Episode.java
@@ -1,6 +1,7 @@
 package annotatedspring.episodes;
 
 import org.hibernate.validator.constraints.NotBlank;
+import org.pegdown.Extensions;
 import org.pegdown.PegDownProcessor;
 
 import javax.persistence.*;
@@ -42,7 +43,7 @@ public class Episode {
     }
 
     public String getNotesHtml() {
-        return new PegDownProcessor().markdownToHtml(notes);
+        return new PegDownProcessor(Extensions.TABLES).markdownToHtml(notes);
     }
 
     public void setId(Integer id) {

--- a/src/test/java/annotatedspring/episodes/EpisodeTest.java
+++ b/src/test/java/annotatedspring/episodes/EpisodeTest.java
@@ -1,10 +1,12 @@
 package annotatedspring.episodes;
 
-import org.junit.Test;
-
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.core.Is.is;
+
+import org.junit.Test;
+
 
 public class EpisodeTest{
 
@@ -30,5 +32,27 @@ public class EpisodeTest{
         episode.setTitle(" no leading nor trailing spaces ");
 
         assertThat(episode.getTitle(), is(equalTo("no leading nor trailing spaces")));
+    }
+    
+    @Test
+    public void markdown_table() {
+        Episode episode = new Episode();
+        String notes = "| Name| Value|\r\n"
+                + "| ---- | ----- |\r\n"
+                + "| Hello| World!|\r\n"
+                + "| Another| Row|\r\n";
+        
+        episode.setNotes(notes);
+        
+        assertThat(episode.getNotesHtml(), containsString("<table>"));
+        assertThat(episode.getNotesHtml(), containsString("<th>Name</th>"));
+        assertThat(episode.getNotesHtml(), containsString("<th>Value</th>"));
+        assertThat(episode.getNotesHtml(), containsString("<tbody>"));
+        assertThat(episode.getNotesHtml(), containsString("<tr>"));
+        assertThat(episode.getNotesHtml(), containsString("<td>Hello</td>"));
+        assertThat(episode.getNotesHtml(), containsString("<td>World!</td>"));
+        assertThat(episode.getNotesHtml(), containsString("</tr>"));
+        assertThat(episode.getNotesHtml(), containsString("</table>"));
+        System.out.println(episode.getNotesHtml());
     }
 }

--- a/src/test/java/annotatedspring/episodes/EpisodeTest.java
+++ b/src/test/java/annotatedspring/episodes/EpisodeTest.java
@@ -45,14 +45,5 @@ public class EpisodeTest{
         episode.setNotes(notes);
         
         assertThat(episode.getNotesHtml(), containsString("<table>"));
-        assertThat(episode.getNotesHtml(), containsString("<th>Name</th>"));
-        assertThat(episode.getNotesHtml(), containsString("<th>Value</th>"));
-        assertThat(episode.getNotesHtml(), containsString("<tbody>"));
-        assertThat(episode.getNotesHtml(), containsString("<tr>"));
-        assertThat(episode.getNotesHtml(), containsString("<td>Hello</td>"));
-        assertThat(episode.getNotesHtml(), containsString("<td>World!</td>"));
-        assertThat(episode.getNotesHtml(), containsString("</tr>"));
-        assertThat(episode.getNotesHtml(), containsString("</table>"));
-        System.out.println(episode.getNotesHtml());
     }
 }


### PR DESCRIPTION
Activates TABLES pegdown's extension to convert markdown tables into HTML.

This pull request kinds of fixes #18.
